### PR TITLE
Vertical scrolling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ snappingLayout.snapPosition = .right
 
 ![right](readmeImages/right.gif)
 
+### Vertical scrolling
+
+With vertical scrolling enabled, `.top`, `.center`, and `.bottom` can snap the cell to their respective parts of the collection view.
+
+```swift
+let snappingLayout = SnappingLayout()
+snappingLayout.snapPosition = .top
+```
+
+![top](readmeImages/top.gif)
+
 ## 💬 Contributing
 This is an open source project, so feel free to contribute. How?
 

--- a/Sources/SnappingLayout/Classes/SnappingLayout.swift
+++ b/Sources/SnappingLayout/Classes/SnappingLayout.swift
@@ -13,6 +13,7 @@ public class SnappingLayout: UICollectionViewFlowLayout {
         case left
         case center
         case right
+        case top
     }
 
     // MARK: - Properties
@@ -29,52 +30,113 @@ public class SnappingLayout: UICollectionViewFlowLayout {
         guard let collectionView = collectionView else {
             return super.targetContentOffset(forProposedContentOffset: proposedContentOffset, withScrollingVelocity: velocity)
         }
-
+        
         var offsetAdjusment = CGFloat.greatestFiniteMagnitude
         let horizontalPosition: CGFloat
-
-        switch snapPosition {
-        case .left:
-            horizontalPosition = proposedContentOffset.x + collectionView.contentInset.left + sectionInset.left
-        case .center:
-            horizontalPosition = proposedContentOffset.x + (collectionView.bounds.width * 0.5)
-        case .right:
-            horizontalPosition = proposedContentOffset.x + collectionView.bounds.width - sectionInset.right
-        }
-
-        let targetRect = CGRect(x: proposedContentOffset.x, y: 0, width: collectionView.bounds.size.width, height: collectionView.bounds.size.height)
-        let layoutAttributesArray = super.layoutAttributesForElements(in: targetRect)
-        layoutAttributesArray?.forEach { layoutAttributes in
-            let itemHorizontalPosition: CGFloat
-
+        let verticalPosition: CGFloat
+        
+        switch scrollDirection {
+        case .horizontal:
             switch snapPosition {
             case .left:
-                itemHorizontalPosition = layoutAttributes.frame.minX - collectionView.contentInset.left
+                horizontalPosition = proposedContentOffset.x + collectionView.contentInset.left + sectionInset.left
+                verticalPosition = proposedContentOffset.y
             case .center:
-                itemHorizontalPosition = layoutAttributes.center.x
+                horizontalPosition = proposedContentOffset.x + (collectionView.bounds.width * 0.5)
+                verticalPosition = proposedContentOffset.y
             case .right:
-                itemHorizontalPosition = layoutAttributes.frame.maxX + collectionView.contentInset.right
+                horizontalPosition = proposedContentOffset.x + collectionView.bounds.width - sectionInset.right
+                verticalPosition = proposedContentOffset.y
+            case .top:
+                horizontalPosition = proposedContentOffset.x
+                verticalPosition = proposedContentOffset.y
             }
-
-            if abs(itemHorizontalPosition - horizontalPosition) < abs(offsetAdjusment) {
-                // If the drag velocity is lower than the minimum velocity (no matter the direction):
-                // snap the current cell to it's original position.
-                if abs(velocity.x) < self.minimumSnapVelocity {
-                    offsetAdjusment = itemHorizontalPosition - horizontalPosition
-                }
-                // If the velocity is higher than the snap threshold and drag is right->left:
-                // move to the next cell on the right.
-                else if velocity.x > 0 {
-                    offsetAdjusment = itemHorizontalPosition - horizontalPosition + (layoutAttributes.bounds.width + self.minimumLineSpacing)
-                }
-                // If the velocity is higher than the snap threshold and drag is left->right:
-                // move to the next cell on the left.
-                else { // velocity.x < 0
-                    offsetAdjusment = itemHorizontalPosition - horizontalPosition - (layoutAttributes.bounds.width + self.minimumLineSpacing)
-                }
+        case .vertical:
+            switch snapPosition {
+            case .left, .right:
+                horizontalPosition = proposedContentOffset.x
+                verticalPosition = proposedContentOffset.y
+            case .center:
+                horizontalPosition = proposedContentOffset.x
+                verticalPosition = proposedContentOffset.y
+            case .top:
+                horizontalPosition = proposedContentOffset.x
+                verticalPosition = proposedContentOffset.y + collectionView.bounds.height - sectionInset.top
             }
         }
+        
+        let targetRect = CGRect(x: proposedContentOffset.x, y: proposedContentOffset.y, width: collectionView.bounds.size.width, height: collectionView.bounds.size.height)
+        let layoutAttributesArray = super.layoutAttributesForElements(in: targetRect)
+        layoutAttributesArray?.forEach { layoutAttributes in
+            
+            switch scrollDirection {
+            case .horizontal:
+                let itemHorizontalPosition: CGFloat
+                
+                switch snapPosition {
+                case .left:
+                    itemHorizontalPosition = layoutAttributes.frame.minX - collectionView.contentInset.left
+                case .center:
+                    itemHorizontalPosition = layoutAttributes.center.x
+                case .right:
+                    itemHorizontalPosition = layoutAttributes.frame.maxX + collectionView.contentInset.right
+                case .top:
+                    itemHorizontalPosition = horizontalPosition
+                }
+                
+                if abs(itemHorizontalPosition - horizontalPosition) < abs(offsetAdjusment) {
+                    // If the drag velocity is lower than the minimum velocity (no matter the direction):
+                    // snap the current cell to it's original position.
+                    if abs(velocity.x) < self.minimumSnapVelocity {
+                        offsetAdjusment = itemHorizontalPosition - horizontalPosition
+                    }
+                    // If the velocity is higher than the snap threshold and drag is right->left:
+                    // move to the next cell on the right.
+                    else if velocity.x > 0 {
+                        offsetAdjusment = itemHorizontalPosition - horizontalPosition + (layoutAttributes.bounds.width + self.minimumLineSpacing)
+                    }
+                    // If the velocity is higher than the snap threshold and drag is left->right:
+                    // move to the next cell on the left.
+                    else { // velocity.x < 0
+                        offsetAdjusment = itemHorizontalPosition - horizontalPosition - (layoutAttributes.bounds.width + self.minimumLineSpacing)
+                    }
+                }
+            case .vertical:
+                let itemVerticalPosition: CGFloat
 
-        return CGPoint(x: proposedContentOffset.x + offsetAdjusment, y: proposedContentOffset.y)
+                switch snapPosition {
+                case .left:
+                    itemVerticalPosition = verticalPosition
+                case .center:
+                    itemVerticalPosition = verticalPosition
+                case .right:
+                    itemVerticalPosition = verticalPosition
+                case .top:
+                    itemVerticalPosition = layoutAttributes.frame.minY - collectionView.contentInset.top
+                }
+                
+                if abs(itemVerticalPosition - verticalPosition) < abs(offsetAdjusment) {
+                    // If the drag velocity is lower than the minimum velocity (no matter the direction):
+                    // snap the current cell to it's original position.
+                    if abs(velocity.y) < self.minimumSnapVelocity {
+                        offsetAdjusment = itemVerticalPosition - verticalPosition
+                    }
+                    // If the velocity is higher than the snap threshold and drag is right->left:
+                    // move to the next cell on the right.
+                    else if velocity.y > 0 {
+                        offsetAdjusment = itemVerticalPosition - verticalPosition + (layoutAttributes.bounds.height + self.minimumLineSpacing)
+                    }
+                    // If the velocity is higher than the snap threshold and drag is left->right:
+                    // move to the next cell on the left.
+                    else { // velocity.x < 0
+                        offsetAdjusment = itemVerticalPosition - verticalPosition - (layoutAttributes.bounds.height + self.minimumLineSpacing)
+                    }
+                }
+            }
+            
+            
+        }
+
+        return CGPoint(x: proposedContentOffset.x + offsetAdjusment, y: proposedContentOffset.y + offsetAdjusment)
     }
 }

--- a/Sources/SnappingLayout/Classes/SnappingLayout.swift
+++ b/Sources/SnappingLayout/Classes/SnappingLayout.swift
@@ -124,13 +124,13 @@ public class SnappingLayout: UICollectionViewFlowLayout {
                     if abs(velocity.y) < self.minimumSnapVelocity {
                         offsetAdjusment = itemVerticalPosition - verticalPosition
                     }
-                    // If the velocity is higher than the snap threshold and drag is right->left:
-                    // move to the next cell on the right.
+                    // If the velocity is higher than the snap threshold and drag is bottom->top:
+                    // move to the next cell on the bottom.
                     else if velocity.y > 0 {
                         offsetAdjusment = itemVerticalPosition - verticalPosition + (layoutAttributes.bounds.height + self.minimumLineSpacing)
                     }
-                    // If the velocity is higher than the snap threshold and drag is left->right:
-                    // move to the next cell on the left.
+                    // If the velocity is higher than the snap threshold and drag is top->bottom:
+                    // move to the next cell on the top.
                     else { // velocity.x < 0
                         offsetAdjusment = itemVerticalPosition - verticalPosition - (layoutAttributes.bounds.height + self.minimumLineSpacing)
                     }

--- a/Sources/SnappingLayout/Classes/SnappingLayout.swift
+++ b/Sources/SnappingLayout/Classes/SnappingLayout.swift
@@ -140,6 +140,11 @@ public class SnappingLayout: UICollectionViewFlowLayout {
             
         }
 
-        return CGPoint(x: proposedContentOffset.x + offsetAdjusment, y: proposedContentOffset.y + offsetAdjusment)
+        switch scrollDirection {
+        case .horizontal:
+            return CGPoint(x: proposedContentOffset.x + offsetAdjusment, y: proposedContentOffset.y)
+        case .vertical:
+            return CGPoint(x: proposedContentOffset.x, y: proposedContentOffset.y + offsetAdjusment)
+        }
     }
 }

--- a/Sources/SnappingLayout/Classes/SnappingLayout.swift
+++ b/Sources/SnappingLayout/Classes/SnappingLayout.swift
@@ -30,7 +30,6 @@ public class SnappingLayout: UICollectionViewFlowLayout {
         guard let collectionView = collectionView else {
             return super.targetContentOffset(forProposedContentOffset: proposedContentOffset, withScrollingVelocity: velocity)
         }
-        
         var offsetAdjusment = CGFloat.greatestFiniteMagnitude
         let horizontalPosition: CGFloat
         let verticalPosition: CGFloat
@@ -58,7 +57,7 @@ public class SnappingLayout: UICollectionViewFlowLayout {
                 verticalPosition = proposedContentOffset.y
             case .center:
                 horizontalPosition = proposedContentOffset.x
-                verticalPosition = proposedContentOffset.y
+                verticalPosition = proposedContentOffset.y + (collectionView.bounds.height * 0.5)
             case .top:
                 horizontalPosition = proposedContentOffset.x
                 verticalPosition = proposedContentOffset.y + collectionView.bounds.height - sectionInset.top
@@ -108,7 +107,7 @@ public class SnappingLayout: UICollectionViewFlowLayout {
                 case .left:
                     itemVerticalPosition = verticalPosition
                 case .center:
-                    itemVerticalPosition = verticalPosition
+                    itemVerticalPosition = layoutAttributes.center.y
                 case .right:
                     itemVerticalPosition = verticalPosition
                 case .top:

--- a/Sources/SnappingLayout/Classes/SnappingLayout.swift
+++ b/Sources/SnappingLayout/Classes/SnappingLayout.swift
@@ -22,7 +22,7 @@ public class SnappingLayout: UICollectionViewFlowLayout {
     /// Position to snap the cells.
     public var snapPosition = SnapPositionType.center
 
-    /// Minimum horizontal velocity to trigger the snap effect.
+    /// Minimum velocity to trigger the snap effect.
     private let minimumSnapVelocity: CGFloat = 0.3
 
     // MARK: - UICollectionViewFlowLayout

--- a/Sources/SnappingLayout/Classes/SnappingLayout.swift
+++ b/Sources/SnappingLayout/Classes/SnappingLayout.swift
@@ -14,6 +14,7 @@ public class SnappingLayout: UICollectionViewFlowLayout {
         case center
         case right
         case top
+        case bottom
     }
 
     // MARK: - Properties
@@ -46,7 +47,7 @@ public class SnappingLayout: UICollectionViewFlowLayout {
             case .right:
                 horizontalPosition = proposedContentOffset.x + collectionView.bounds.width - sectionInset.right
                 verticalPosition = proposedContentOffset.y
-            case .top:
+            case .top, .bottom:
                 horizontalPosition = proposedContentOffset.x
                 verticalPosition = proposedContentOffset.y
             }
@@ -61,6 +62,9 @@ public class SnappingLayout: UICollectionViewFlowLayout {
             case .top:
                 horizontalPosition = proposedContentOffset.x
                 verticalPosition = proposedContentOffset.y + collectionView.bounds.height - sectionInset.top
+            case .bottom:
+                horizontalPosition = proposedContentOffset.x
+                verticalPosition = proposedContentOffset.y + collectionView.bounds.height - sectionInset.bottom
             }
         }
         
@@ -79,7 +83,7 @@ public class SnappingLayout: UICollectionViewFlowLayout {
                     itemHorizontalPosition = layoutAttributes.center.x
                 case .right:
                     itemHorizontalPosition = layoutAttributes.frame.maxX + collectionView.contentInset.right
-                case .top:
+                case .top, .bottom:
                     itemHorizontalPosition = horizontalPosition
                 }
                 
@@ -104,14 +108,14 @@ public class SnappingLayout: UICollectionViewFlowLayout {
                 let itemVerticalPosition: CGFloat
 
                 switch snapPosition {
-                case .left:
+                case .left, .right:
                     itemVerticalPosition = verticalPosition
                 case .center:
                     itemVerticalPosition = layoutAttributes.center.y
-                case .right:
-                    itemVerticalPosition = verticalPosition
                 case .top:
                     itemVerticalPosition = layoutAttributes.frame.minY - collectionView.contentInset.top
+                case .bottom:
+                    itemVerticalPosition = layoutAttributes.frame.minY + collectionView.contentInset.bottom
                 }
                 
                 if abs(itemVerticalPosition - verticalPosition) < abs(offsetAdjusment) {


### PR DESCRIPTION
The logic for horizontal scrolling moved inside switch statements for `scrollDirection`.

I added three cases for `.vertical` scrolling:
- `.top`
- `.center`
- `.bottom`

The cells of a collectionView snap to the top, center, or bottom when the `scrollDirection` is set to `vertical`.

